### PR TITLE
Fixes #71 Enums added and hopper operation is decoupled

### DIFF
--- a/roborio/FROGlib/subsystem.py
+++ b/roborio/FROGlib/subsystem.py
@@ -5,6 +5,12 @@ from commands2 import Subsystem
 from wpilib import DataLogManager
 from wpiutil.log import DoubleLogEntry, BooleanLogEntry, StringLogEntry
 from wpimath.geometry import Pose2d
+from enum import Enum
+
+class Direction(Enum):
+    FORWARD = 1
+    REVERSE = -1
+    IDLE = 0
 
 
 class Tunable:

--- a/roborio/robotcontainer.py
+++ b/roborio/robotcontainer.py
@@ -10,6 +10,7 @@ from subsystems.intake import Intake
 from subsystems.feeder import Feeder
 from subsystems.drive import Drive
 from FROGlib.xbox import FROGXboxDriver
+from FROGlib.subsystem import Direction
 from commands2.sysid import SysIdRoutine
 from phoenix6 import SignalLogger
 from commands2.button import Trigger
@@ -68,8 +69,16 @@ class RobotContainer:
 
     def configure_automation_bindings(self) -> None:
         """Configure automation bindings for the robot."""
-        # Configure automation bindings
-        pass
+        # The hopper should run forward whenever either the intake OR the feed motors are running forward.
+        Trigger(
+            lambda: self.intake.get_direction() == Direction.FORWARD
+            or self.feeder.get_direction() == Direction.FORWARD
+        ).whileTrue(self.hopper.runForward())
+        # The hopper should run backward whenever either the intake OR the feed motors are running backward.
+        Trigger(
+            lambda: self.intake.get_direction() == Direction.REVERSE
+            or self.feeder.get_direction() == Direction.REVERSE
+        ).whileTrue(self.hopper.runBackward())
 
     def configure_xbox_bindings(self) -> None:
         """Configure button bindings for the xboxcontrollers."""
@@ -93,16 +102,19 @@ class RobotContainer:
             self.drive.runOnce(self.drive.reset_initial_pose)
         )
         # self.driver_xbox.y().whileTrue(self.climber.lift_to_position(7.3))
-        # self.driver_xbox.x().whileTrue(self.climber.deploy_to_position(1.5))
-        self.driver_xbox.b().whileTrue(
-            self.intake.runForward().alongWith(self.hopper.runForward())
+
+        # Reverse intake and feed motors to empty the hopper (hopper will follow automatically via triggers)
+        self.driver_xbox.x().whileTrue(
+            self.intake.runBackward()
+            .alongWith(self.feeder.runBackward())
+            .withName("Eject All")
         )
+
+        self.driver_xbox.b().whileTrue(self.intake.runForward())
         self.fuel_detector.get_trigger_targets_close().whileTrue(
-            self.intake.runForward().alongWith(self.hopper.runForward())
+            self.intake.runForward()
         )
-        self.driver_xbox.y().toggleOnTrue(
-            self.intake.runForward().alongWith(self.hopper.runForward())
-        )
+        self.driver_xbox.y().toggleOnTrue(self.intake.runForward())
 
         safe_to_shoot = self.field_zones.get_no_shoot_trigger().negate()
 
@@ -112,7 +124,7 @@ class RobotContainer:
                 cmd.waitUntil(self.shooter.is_hood_deployed),
                 self.shooter.cmd_fire_at_set_speed().alongWith(
                     cmd.waitUntil(self.shooter.is_at_speed).andThen(
-                        self.hopper.runForward().alongWith(self.feeder.runForward())
+                        self.feeder.runForward()
                     )
                 ),
             )

--- a/roborio/subsystems/feeder.py
+++ b/roborio/subsystems/feeder.py
@@ -2,7 +2,7 @@ from commands2 import Command
 from commands2.sysid import SysIdRoutine
 from wpilib.sysid import SysIdRoutineLog
 from wpimath.system.plant import DCMotor, LinearSystemId
-from FROGlib.subsystem import FROGSubsystem
+from FROGlib.subsystem import FROGSubsystem, Direction
 from phoenix6.controls import VoltageOut
 from phoenix6 import controls, SignalLogger
 from FROGlib.ctre import (
@@ -127,6 +127,15 @@ class Feeder(FROGSubsystem):
 
     def stop(self):
         self.motor.stopMotor()
+
+    def get_direction(self) -> Direction:
+        voltage = self.motor.get_motor_voltage().value
+        if voltage > 0.1:
+            return Direction.FORWARD
+        elif voltage < -0.1:
+            return Direction.REVERSE
+        else:
+            return Direction.IDLE
 
     def simulationPeriodic(self):
         dt = 0.020

--- a/roborio/subsystems/intake.py
+++ b/roborio/subsystems/intake.py
@@ -8,7 +8,7 @@ from FROGlib.ctre import (
 import constants
 from phoenix6 import controls
 from FROGlib.ctre import MOTOR_OUTPUT_CWP_COAST, MOTOR_OUTPUT_CCWP_COAST
-from FROGlib.subsystem import FROGSubsystem
+from FROGlib.subsystem import FROGSubsystem, Direction
 import wpilib
 
 
@@ -55,8 +55,14 @@ class Intake(FROGSubsystem):
         self.motor.stopMotor()
 
     # Optional: helper to check if motor is actively driven
-    def _is_running(self) -> bool:
-        return abs(self.motor.get_motor_voltage().value) > 0
+    def get_direction(self) -> Direction:
+        voltage = self.motor.get_motor_voltage().value
+        if voltage > 0.1:
+            return Direction.FORWARD
+        elif voltage < -0.1:
+            return Direction.REVERSE
+        else:
+            return Direction.IDLE
 
     # ────────────────────────────────────────────────
     #          Command Factory Methods


### PR DESCRIPTION
Fixes #71  Decoupled hopper ops from intake and feeder parallel commands.  Introduced new enum to identify the running mechanism direction.